### PR TITLE
formatUnitSize expects size as (human readable) string

### DIFF
--- a/CRM/Committees/Form/Import.php
+++ b/CRM/Committees/Form/Import.php
@@ -51,7 +51,7 @@ class CRM_Committees_Form_Import extends CRM_Core_Form
             TRUE
         );
 
-        $max_size = CRM_Utils_Number::formatUnitSize(1024 * 1024 * 8, true);
+        $max_size = CRM_Utils_Number::formatUnitSize('8M', TRUE);
         $this->setMaxFileSize($max_size);
 
         // default values:


### PR DESCRIPTION
Fixes a notice error when showing the upload form. 
> Notice: Trying to access array offset on value of type int in CRM_Utils_Number::formatUnitSize() (line 78 of /opt/buildkit/build/dmaster/sites/all/modules/civicrm/CRM/Utils/Number.php).