### PR TITLE
Avoid warnings when argv is not set

### DIFF
--- a/CRM/Committees/Plugin/Base.php
+++ b/CRM/Committees/Plugin/Base.php
@@ -193,7 +193,7 @@ abstract class CRM_Committees_Plugin_Base
     {
         static $is_unit_test = null;
         if ($is_unit_test === null) {
-            $is_unit_test = (strpos($_SERVER['argv'][0], 'phpunit') !== FALSE);
+            $is_unit_test = (strpos($_SERVER['argv'][0] ?? '', 'phpunit') !== FALSE);
         }
         return $is_unit_test;
     }


### PR DESCRIPTION
Avoid warnings when argv is not set 

> Notice: Undefined index: argv in CRM_Committees_Plugin_Base->isUnitTest() (line 196 of /opt/buildkit/build/dmaster/sites/default/files/civicrm/ext/de.systopia.committees/CRM/Committees/Plugin/Base.php).

> Notice: Trying to access array offset on value of type null in CRM_Committees_Plugin_Base->isUnitTest() (line 196 of /opt/buildkit/build/dmaster/sites/default/files/civicrm/ext/de.systopia.committees/CRM/Committees/Plugin/Base.php).