### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Committees/Implementation/OxfamSimpleSync.php
+++ b/CRM/Committees/Implementation/OxfamSimpleSync.php
@@ -990,7 +990,7 @@ class CRM_Committees_Implementation_OxfamSimpleSync extends CRM_Committees_Plugi
                     }
                 }
             }
-            throw new CiviCRM_API3_Exception("Couldn't identify parliament name!");
+            throw new CRM_Core_Exception("Couldn't identify parliament name!");
         }
         return $parliament_name;
     }

--- a/CRM/Committees/Implementation/PersonalOfficeSyncer.php
+++ b/CRM/Committees/Implementation/PersonalOfficeSyncer.php
@@ -704,7 +704,7 @@ class CRM_Committees_Implementation_PersonalOfficeSyncer extends CRM_Committees_
                 ];
                 CRM_Committees_CustomData::resolveCustomFields($ekir_field_query);
                 $employer_contact = civicrm_api3('Contact', 'getsingle', $ekir_field_query);
-            } catch (CiviCRM_API3_Exception $ex) {
+            } catch (CRM_Core_Exception $ex) {
                 $this->log("EKIR entity [{$employer_ekir_id}] is listed as employer, but wasn't not found in the system.");
                 continue;
             }
@@ -719,7 +719,7 @@ class CRM_Committees_Implementation_PersonalOfficeSyncer extends CRM_Committees_
                         //                    'description' => $employment->getAttribute('title'),
                 ]);
                 $employments_imported++;
-            } catch (CiviCRM_API3_Exception $ex) {
+            } catch (CRM_Core_Exception $ex) {
                 $this->log("Couldn't create EKIR employment of [{$employee_id}] with [{$employer_contact['id']}]: " . $ex->getMessage());
                 continue;
             }

--- a/CRM/Committees/Implementation/SessionSyncer.php
+++ b/CRM/Committees/Implementation/SessionSyncer.php
@@ -721,7 +721,7 @@ class CRM_Committees_Implementation_SessionSyncer extends CRM_Committees_Plugin_
                     'description' => $membership->getAttribute('title'),
                 ];
                 civicrm_api3('Relationship', 'create', $relationship_params);
-            } catch (CiviCRM_API3_Exception $exception) {
+            } catch (CRM_Core_Exception $exception) {
                 $this->logException($exception, "Relationship between person [{$person->getID()}] and committee [{$gremium->getID()}] could not be created. Error was " . $exception->getMessage());
             }
         }

--- a/CRM/Committees/Plugin/Base.php
+++ b/CRM/Committees/Plugin/Base.php
@@ -435,7 +435,7 @@ abstract class CRM_Committees_Plugin_Base
                 }
             }
             return civicrm_api3($entity, $action, $params);
-        } catch (CiviCRM_API3_Exception $ex) {
+        } catch (CRM_Core_Exception $ex) {
             $this->logException($ex);
             return civicrm_api3_create_error("Error: " . $ex->getMessage());
         }

--- a/CRM/Committees/Plugin/Syncer.php
+++ b/CRM/Committees/Plugin/Syncer.php
@@ -113,7 +113,7 @@ abstract class CRM_Committees_Plugin_Syncer extends CRM_Committees_Plugin_Base
                     'name_a_b' => $relationship_type_name_ab,
                     'return' => 'id'
                 ]);
-            } catch (CiviCRM_API3_Exception $ex) {
+            } catch (CRM_Core_Exception $ex) {
                 $this->logError("RelationshipType '{$relationship_type_name_ab}' not found.");
                 return null;
             }


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.