### PR TITLE
replace call to getCellByColumnAndRow() with getCell()

### DIFF
--- a/CRM/Committees/Implementation/KuerschnerCsvImporter.php
+++ b/CRM/Committees/Implementation/KuerschnerCsvImporter.php
@@ -434,7 +434,7 @@ class CRM_Committees_Implementation_KuerschnerCsvImporter extends CRM_Committees
         $record = [];
         foreach ($col2field as $column_number => $field_name) {
             /** @var \PhpOffice\PhpSpreadsheet\Cell\Cell $cell */
-            $cell = $sheet->getCellByColumnAndRow($column_number, $row_number, false);
+            $cell = $sheet->getCell([$column_number, $row_number]);
             $record[$field_name] = trim($cell->getValue());
         }
         return $record;

--- a/CRM/Committees/Implementation/PersonalOfficeImporter.php
+++ b/CRM/Committees/Implementation/PersonalOfficeImporter.php
@@ -216,7 +216,7 @@ class CRM_Committees_Implementation_PersonalOfficeImporter extends CRM_Committee
         $record = [];
         foreach ($col2field as $column_number => $field_name) {
             /** @var \PhpOffice\PhpSpreadsheet\Cell\Cell $cell */
-            $cell = $sheet->getCellByColumnAndRow($column_number, $row_number, false);
+            $cell = $sheet->getCell([$column_number, $row_number]);
             $value = $cell->getValue();
             if (is_string($value)) {
                 $value = trim($value);

--- a/CRM/Committees/Implementation/SessionImporter.php
+++ b/CRM/Committees/Implementation/SessionImporter.php
@@ -338,7 +338,7 @@ class CRM_Committees_Implementation_SessionImporter extends CRM_Committees_Plugi
         $record = [];
         foreach ($col2field as $column_number => $field_name) {
             /** @var \PhpOffice\PhpSpreadsheet\Cell\Cell $cell */
-            $cell = $sheet->getCellByColumnAndRow($column_number, $row_number, false);
+            $cell = $sheet->getCell([$column_number, $row_number]);
             $record[$field_name] = trim($cell->getValue());
         }
         return $record;

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
   "require": {
-    "phpoffice/phpspreadsheet": "^1.30"
+    "phpoffice/phpspreadsheet": "^2"
   }
 }


### PR DESCRIPTION
systopia-reference: 34005

- increased version of php-spreadsheet dependency to 2
- replaced deprecated call `Spreadsheet::getCellByColumnAndRow()` with call to `Spreadsheet::getCell()`